### PR TITLE
feat(polyglot): add T component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.2](https://github.com/pmmmwh/react-polyglot-hooks/compare/v0.1.1...v0.1.2) (2019-08-27)
+
+### Features
+
+- **polyglot:** add T component for easy phrase consumption ([6d6d32c](https://github.com/pmmmwh/react-polyglot-hooks/commit/6d6d32c))
+
 ### [0.1.1](https://github.com/pmmmwh/react-polyglot-hooks/compare/v0.1.0...v0.1.1) (2019-08-26)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ yarn add react-polyglot-hooks
 
 ## Usage
 
-React Polyglot Hooks offers 1 wrapper component: `<I18n>` and 2 hooks: `useLocale` and `useTranslate`.
-The hooks have to be wrapped with the `<I18n>` component to work properly.
+React Polyglot Hooks offers 1 wrapper component: `<I18n>`, 2 hooks: `useLocale` and `useTranslate` and 1 helper component: `<T>`
+The hooks and the helper component have to be wrapped with the `<I18n>` component to work properly.
 
 Here is a quick example to get you started:
 First, wrap a parent component with `<I18n>` and provide `locale` and `phrases`.
@@ -66,16 +66,14 @@ Then, in a child component, call the hooks:
 
 ```jsx
 import React from 'react';
-import { useLocale, useTranslate } from 'react-polyglot-hooks';
+import { T, useLocale } from 'react-polyglot-hooks';
 
 export default function Child() {
   const locale = useLocale(); // Current locale: "en"
-  const t = useTranslate(); // Translate function, see below
-
   return (
     <React.Fragment>
       <span>{locale}</span>
-      <span>{t('hello')}</span>
+      <T phrase="hello" />
     </React.Fragment>
   );
 }
@@ -103,6 +101,17 @@ Provides i18n context to the hooks. Accepts all options supported by [Polyglot.j
 | `allowMissing`  | `boolean`                                                                | ❌       | Controls whether missing keys in a `t` call is allowed.                           |
 | `onMissingKey`  | `(key: string, options: InterpolationOptions, locale: string) => string` | ❌       | A function called when `allowMissing` is `true` and a missing key is encountered. |
 | `interpolation` | `{ prefix: string, suffix: string }`                                     | ❌       | Controls the prefix and suffix for an interpolation.                              |
+
+### `<T>`
+
+Renders a phrase according to the props.
+
+#### Props
+
+| Props     | Type                                    | Required | Description                       |
+| --------- | --------------------------------------- | -------- | --------------------------------- |
+| `phrase`  | `string`                                | ✅       | Key of the needed phrase.         |
+| `options` | `number` or `{ [key: string]: string }` | ❌       | See `InterpolationOptions` below. |
 
 ### `useLocale`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-polyglot-hooks",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Hooks for using Polyglot.js with React.",
   "keywords": [
     "react",

--- a/src/T.tsx
+++ b/src/T.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { InterpolationOptions } from 'node-polyglot';
+import useTranslate from './useTranslate';
+
+export interface TProps {
+  phrase: string;
+  options?: number | InterpolationOptions;
+}
+
+const T: React.FC<TProps> = ({ phrase, options }) => {
+  const t = useTranslate();
+  // HACK: A workaround for the current limitations of TSX with FC
+  // Ref: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544
+  return (t(phrase, options) as unknown) as React.ReactElement;
+};
+
+export default T;

--- a/src/__tests__/T.test.tsx
+++ b/src/__tests__/T.test.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import I18n from '../I18n';
+import T from '../T';
+
+describe('T Component', () => {
+  const originalConsoleError = console.error;
+
+  let consoleOutput: string[] = [];
+  beforeEach(() => {
+    console.error = (...args: string[]): void => {
+      args.forEach(arg => consoleOutput.push(arg));
+    };
+  });
+
+  afterEach(() => {
+    consoleOutput = [];
+    console.error = originalConsoleError;
+  });
+
+  it('should render key and warn without context', () => {
+    const { getByText } = render(<T phrase="phrase" />);
+    expect(getByText('phrase')).toBeInTheDocument();
+    expect(consoleOutput).toHaveLength(1);
+    expect(consoleOutput[0]).toBe(
+      'Warning: t is called without Polyglot context. Perhaps you need to wrap the component in <I18n>?'
+    );
+  });
+
+  it('should render available message with context', () => {
+    const tree = (
+      <I18n locale="en" phrases={{ phrase: 'Message' }}>
+        <T phrase="phrase" />
+      </I18n>
+    );
+    const { getByText, queryByText } = render(tree);
+    expect(queryByText('phrase')).not.toBeInTheDocument();
+    expect(getByText('Message')).toBeInTheDocument();
+    expect(consoleOutput).toHaveLength(0);
+  });
+
+  it('should render key and warn for unavailable message with context', () => {
+    const tree = (
+      <I18n locale="en" phrases={{ phrase: 'Message' }}>
+        <T phrase="unavailable" />
+      </I18n>
+    );
+    const { getByText, queryByText } = render(tree);
+    expect(queryByText('phrase')).not.toBeInTheDocument();
+    expect(queryByText('Message')).not.toBeInTheDocument();
+    expect(getByText('unavailable')).toBeInTheDocument();
+    expect(consoleOutput).toHaveLength(1);
+    expect(consoleOutput[0]).toBe(
+      'Warning: Missing translation for key: "unavailable"'
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { default as I18n, I18nProps } from './I18n';
 export { I18nContextProps } from './i18nContext';
+export { default as T, TProps } from './T';
 export { default as useLocale } from './useLocale';
 export { default as useTranslate } from './useTranslate';


### PR DESCRIPTION
This PR adds a helper component to reduce the clutter when working with `useTranslate`.

- [x] Implementation of the component
- [x] Tests for the component
- [x] Document the component