### PR TITLE
feat(use-t): rename use translate to use t

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ yarn add react-polyglot-hooks
 ```
 
 > React is required as a peer dependency.
-> Please install version 16.8.0 or later (minimum requirement for hooks).
+> Please install version 16.8.3 or later (minimum requirement for hooks).
 
 ## Usage
 
-React Polyglot Hooks offers 1 wrapper component: `<I18n>`, 2 hooks: `useLocale` and `useTranslate` and 1 helper component: `<T>`.
+React Polyglot Hooks offers 1 wrapper component: `<I18n>`, 2 hooks: `useLocale` and `useT` and 1 helper component: `<T>`.
 The hooks and the helper component have to be wrapped with the `<I18n>` component to work properly.
 
 Here is a quick example to get you started:
@@ -121,7 +121,7 @@ Renders a phrase according to the props.
 
 Returns the current active locale (`string`).
 
-### `useTranslate`
+### `useT`
 
 Returns a special function (`t`) which takes in parameters and returns a phrase.
 

--- a/src/T.tsx
+++ b/src/T.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { InterpolationOptions } from 'node-polyglot';
 import { NO_NUMBER_INTERPOLATIONS } from './constants';
-import useTranslate from './useTranslate';
+import useT from './useT';
 
 export interface TProps {
   count?: number;
@@ -11,7 +11,7 @@ export interface TProps {
 }
 
 const T: React.FC<TProps> = ({ count, fallback, interpolations, phrase }) => {
-  const t = useTranslate();
+  const t = useT();
 
   let cleanInterpolations;
   if (typeof interpolations !== 'number') {

--- a/src/__tests__/useT.test.tsx
+++ b/src/__tests__/useT.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
-import { I18n, useTranslate } from '..';
+import { I18n, useT } from '..';
 import { NO_POLYGLOT_CONTEXT } from '../constants';
 
-describe('Use Translate', () => {
+describe('Use T', () => {
   const originalConsoleError = console.error;
 
   let consoleOutput: string[] = [];
@@ -19,13 +19,13 @@ describe('Use Translate', () => {
   });
 
   it('should return a function', () => {
-    const { result } = renderHook(() => useTranslate());
+    const { result } = renderHook(() => useT());
     expect(typeof result.current).toBe('function');
   });
 
   describe('when context is not provided', () => {
     it('should return key on call and emit a warning', () => {
-      const { result } = renderHook(() => useTranslate());
+      const { result } = renderHook(() => useT());
       const callResult = result.current('phrase');
       expect(callResult).toBe('phrase');
       expect(consoleOutput).toHaveLength(1);
@@ -41,7 +41,7 @@ describe('Use Translate', () => {
             {children}
           </I18n>
         );
-        const { result } = renderHook(() => useTranslate(), { wrapper });
+        const { result } = renderHook(() => useT(), { wrapper });
         const callResult = result.current('unavailable');
         expect(callResult).toBe('unavailable');
         expect(consoleOutput).toHaveLength(1);
@@ -56,7 +56,7 @@ describe('Use Translate', () => {
             {children}
           </I18n>
         );
-        const { result } = renderHook(() => useTranslate(), { wrapper });
+        const { result } = renderHook(() => useT(), { wrapper });
         const callResult = result.current('unavailable', {
           message: 'Failed!',
         });
@@ -70,7 +70,7 @@ describe('Use Translate', () => {
             {children}
           </I18n>
         );
-        const { result } = renderHook(() => useTranslate(), { wrapper });
+        const { result } = renderHook(() => useT(), { wrapper });
         const callResult = result.current('unavailable', {
           _: 'Fallback: %{message}',
           message: 'Success!',
@@ -87,7 +87,7 @@ describe('Use Translate', () => {
             {children}
           </I18n>
         );
-        const { result } = renderHook(() => useTranslate(), { wrapper });
+        const { result } = renderHook(() => useT(), { wrapper });
         const callResult = result.current('phrase');
         expect(callResult).toBe('Message');
         expect(consoleOutput).toHaveLength(0);
@@ -99,7 +99,7 @@ describe('Use Translate', () => {
             {children}
           </I18n>
         );
-        const { result } = renderHook(() => useTranslate(), { wrapper });
+        const { result } = renderHook(() => useT(), { wrapper });
         const callResult = result.current('phrase', {
           message: 'Success!',
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,4 @@ export { default as I18n, I18nProps } from './I18n';
 export { I18nContextProps } from './i18nContext';
 export { default as T, TProps } from './T';
 export { default as useLocale } from './useLocale';
-export { default as useTranslate } from './useTranslate';
+export { default as useT } from './useT';

--- a/src/useT.ts
+++ b/src/useT.ts
@@ -2,9 +2,9 @@ import { useContext } from 'react';
 import { PolyglotT } from './constants';
 import I18nContext from './i18nContext';
 
-const useTranslate = (): PolyglotT => {
+const useT = (): PolyglotT => {
   const { t } = useContext(I18nContext);
   return t;
 };
 
-export default useTranslate;
+export default useT;

--- a/src/vendors.d.ts
+++ b/src/vendors.d.ts
@@ -1,4 +1,5 @@
 // Override Type definitions for node-polyglot v2.3.1
+// TODO: Remove after PR is merged in DefinitelyTyped
 import { InterpolationOptions, PolyglotOptions } from 'node-polyglot';
 
 declare module 'node-polyglot' {


### PR DESCRIPTION
For DX purposes and to align naming with Polyglot, this PR renames the `useTranslate` hook to `useT`. This is a breaking change.