### PR TITLE
feat: component interpolations

### DIFF
--- a/src/I18n.tsx
+++ b/src/I18n.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Polyglot, { PolyglotOptions } from 'node-polyglot';
-import { PolyglotT } from './constants';
+import enhanceT from './enhanceT';
 import I18nContext from './i18nContext';
 
 export interface I18nProps extends PolyglotOptions {
@@ -33,10 +33,7 @@ const I18n: React.FC<I18nProps> = ({
   const polyglotContext = React.useMemo(
     () => ({
       locale: polyglot.locale(),
-      // We use a named function here to aid debugging
-      t(...args: Parameters<PolyglotT>): ReturnType<PolyglotT> {
-        return polyglot.t(...args);
-      },
+      t: enhanceT(polyglot.t.bind(polyglot)),
     }),
     [polyglot]
   );

--- a/src/__tests__/I18n.test.tsx
+++ b/src/__tests__/I18n.test.tsx
@@ -11,24 +11,6 @@ describe('I18n Provider', () => {
     render(<I18n locale="" phrases={{}} />);
   });
 
-  it('should only pass locale and t to children via context', () => {
-    const readValue = spy();
-    const tree = (
-      <I18n locale="en" phrases={{}}>
-        <I18nContext.Consumer>
-          {values => <ValueTester callback={readValue} value={values} />}
-        </I18nContext.Consumer>
-      </I18n>
-    );
-    render(tree);
-    const calledValue = readValue.getCall(0).args[0];
-    expect(typeof calledValue).toBe('object');
-
-    const valueKeys = Object.keys(calledValue);
-    expect(valueKeys).toHaveLength(2);
-    expect(valueKeys).toStrictEqual(['locale', 't']);
-  });
-
   it('should provide a locale from Polyglot', () => {
     const tree = (
       <I18n locale="en" phrases={{}}>
@@ -65,6 +47,7 @@ describe('I18n Provider', () => {
     render(tree);
     const calledValue = readValue.getCall(0).args[0];
     expect(typeof calledValue).toBe('function');
+    expect(calledValue.toString()).toContain('function t');
     expect(calledValue('phrase')).toBe('Message');
   });
 

--- a/src/__tests__/T.test.tsx
+++ b/src/__tests__/T.test.tsx
@@ -67,7 +67,7 @@ describe('T Component', () => {
   });
 
   describe('when a phrase is found', () => {
-    it('should render without warning', () => {
+    it('should render without crashing', () => {
       const tree = (
         <I18n locale="en" phrases={{ phrase: 'Message' }}>
           <T phrase="phrase" />
@@ -75,7 +75,6 @@ describe('T Component', () => {
       );
       const { getByText } = render(tree);
       expect(getByText('Message')).toBeInTheDocument();
-      expect(consoleOutput).toHaveLength(0);
     });
 
     it('should interpolate values', () => {

--- a/src/__tests__/T.test.tsx
+++ b/src/__tests__/T.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { I18n, T } from '..';
-import { NO_NUMBER_INTERPOLATIONS, NO_POLYGLOT_CONTEXT } from '../constants';
+import { NO_NUMBER_INTERPOLATIONS } from '../constants';
 
 describe('T Component', () => {
   const originalConsoleWarn = console.warn;
@@ -24,172 +24,107 @@ describe('T Component', () => {
     console.warn = originalConsoleWarn;
   });
 
-  describe('when context is not provided', () => {
-    it('should render the key and emit a warning', () => {
-      const { getByText } = render(<T phrase="phrase" />);
-      expect(getByText('phrase')).toBeInTheDocument();
-      expect(consoleOutput).toHaveLength(1);
-      expect(consoleOutput[0]).toBe(NO_POLYGLOT_CONTEXT);
+  describe('when a phrase is not found', () => {
+    it('should render the key', () => {
+      const tree = (
+        <I18n locale="en" phrases={{ phrase: 'Message' }}>
+          <T phrase="unavailable" />
+        </I18n>
+      );
+      const { getByText, queryByText } = render(tree);
+      expect(queryByText('phrase')).not.toBeInTheDocument();
+      expect(queryByText('Message')).not.toBeInTheDocument();
+      expect(getByText('unavailable')).toBeInTheDocument();
+    });
+
+    it('should render the fallback when available', () => {
+      const tree = (
+        <I18n locale="en" phrases={{ phrase: 'Message' }}>
+          <T phrase="unavailable" fallback="Fallback" />
+        </I18n>
+      );
+      const { getByText, queryByText } = render(tree);
+      expect(queryByText('phrase')).not.toBeInTheDocument();
+      expect(queryByText('Message')).not.toBeInTheDocument();
+      expect(getByText('Fallback')).toBeInTheDocument();
+      expect(consoleOutput).toHaveLength(0);
+    });
+
+    it('should allow interpolations to override fallback', () => {
+      const tree = (
+        <I18n locale="en" phrases={{ phrase: 'Message' }}>
+          <T
+            phrase="unavailable"
+            fallback="Incorrect"
+            interpolations={{ _: 'Fallback' }}
+          />
+        </I18n>
+      );
+      const { getByText, queryByText } = render(tree);
+      expect(queryByText('Incorrect')).not.toBeInTheDocument();
+      expect(getByText('Fallback')).toBeInTheDocument();
     });
   });
 
-  describe('when context is provided', () => {
-    describe('when a phrase is not found', () => {
-      it('should render the key and emit a warning', () => {
-        const tree = (
-          <I18n locale="en" phrases={{ phrase: 'Message' }}>
-            <T phrase="unavailable" />
-          </I18n>
-        );
-        const { getByText, queryByText } = render(tree);
-        expect(queryByText('phrase')).not.toBeInTheDocument();
-        expect(queryByText('Message')).not.toBeInTheDocument();
-        expect(getByText('unavailable')).toBeInTheDocument();
-        expect(consoleOutput).toHaveLength(1);
-        expect(consoleOutput[0]).toBe(
-          'Warning: Missing translation for key: "unavailable"'
-        );
-      });
-
-      it('should render the fallback without warning', () => {
-        const tree = (
-          <I18n locale="en" phrases={{ phrase: 'Message' }}>
-            <T phrase="unavailable" fallback="Fallback" />
-          </I18n>
-        );
-        const { getByText, queryByText } = render(tree);
-        expect(queryByText('phrase')).not.toBeInTheDocument();
-        expect(queryByText('Message')).not.toBeInTheDocument();
-        expect(getByText('Fallback')).toBeInTheDocument();
-        expect(consoleOutput).toHaveLength(0);
-      });
-
-      it('should interpolate values to a fallback', () => {
-        const tree = (
-          <I18n locale="en" phrases={{ phrase: 'Interpolated: %{message}' }}>
-            <T
-              phrase="unavailable"
-              fallback="Fallback: %{message}"
-              interpolations={{ message: 'Success!' }}
-            />
-          </I18n>
-        );
-        const { getByText, queryByText } = render(tree);
-        expect(queryByText(/^Interpolated:/)).not.toBeInTheDocument();
-        expect(getByText(/^Fallback: /)).toBeInTheDocument();
-        expect(getByText(/^Fallback: /).textContent).toBe('Fallback: Success!');
-      });
-
-      it('should not interpolate values without a fallback', () => {
-        const tree = (
-          <I18n locale="en" phrases={{ phrase: 'Interpolated: %{message}' }}>
-            <T phrase="unavailable" interpolations={{ message: 'Success!' }} />
-          </I18n>
-        );
-        const { getByText, queryByText } = render(tree);
-        expect(queryByText(/^Interpolated:/)).not.toBeInTheDocument();
-        expect(queryByText(/Success!/)).not.toBeInTheDocument();
-        expect(getByText('unavailable')).toBeInTheDocument();
-        expect(getByText('unavailable').textContent).toBe('unavailable');
-      });
-
-      it('should allow interpolations to override fallback', () => {
-        const tree = (
-          <I18n locale="en" phrases={{ phrase: 'Message' }}>
-            <T
-              phrase="unavailable"
-              fallback="Incorrect"
-              interpolations={{ _: 'Fallback' }}
-            />
-          </I18n>
-        );
-        const { getByText, queryByText } = render(tree);
-        expect(queryByText('Incorrect')).not.toBeInTheDocument();
-        expect(getByText('Fallback')).toBeInTheDocument();
-      });
+  describe('when a phrase is found', () => {
+    it('should render without warning', () => {
+      const tree = (
+        <I18n locale="en" phrases={{ phrase: 'Message' }}>
+          <T phrase="phrase" />
+        </I18n>
+      );
+      const { getByText } = render(tree);
+      expect(getByText('Message')).toBeInTheDocument();
+      expect(consoleOutput).toHaveLength(0);
     });
 
-    describe('when a phrase is found', () => {
-      it('should render without warning', () => {
-        const tree = (
-          <I18n locale="en" phrases={{ phrase: 'Message' }}>
-            <T phrase="phrase" />
-          </I18n>
-        );
-        const { getByText } = render(tree);
-        expect(getByText('Message')).toBeInTheDocument();
-        expect(consoleOutput).toHaveLength(0);
-      });
+    it('should interpolate values', () => {
+      const tree = (
+        <I18n locale="en" phrases={{ phrase: 'Interpolated: %{message}' }}>
+          <T phrase="phrase" interpolations={{ message: 'Success!' }} />
+        </I18n>
+      );
+      const { getByText } = render(tree);
+      expect(getByText(/^Interpolated:/)).toBeInTheDocument();
+      expect(getByText(/^Interpolated:/).textContent).toBe(
+        'Interpolated: Success!'
+      );
+    });
 
-      it('should render the phrase even a fallback is provided', () => {
-        const tree = (
-          <I18n locale="en" phrases={{ phrase: 'Message' }}>
-            <T phrase="phrase" fallback="Fallback" />
-          </I18n>
-        );
-        const { getByText, queryByText } = render(tree);
-        expect(queryByText('phrase')).not.toBeInTheDocument();
-        expect(queryByText('Fallback')).not.toBeInTheDocument();
-        expect(getByText('Message')).toBeInTheDocument();
-      });
+    it('should interpolate number as smart count with deprecation warning', () => {
+      const tree = (
+        <I18n locale="en" phrases={{ phrase: 'Interpolated: %{smart_count}' }}>
+          <T phrase="phrase" interpolations={1} />
+        </I18n>
+      );
+      const { getByText } = render(tree);
+      expect(getByText(/^Interpolated:/)).toBeInTheDocument();
+      expect(getByText(/^Interpolated:/).textContent).toBe('Interpolated: 1');
+      expect(consoleOutput).toHaveLength(1);
+      expect(consoleOutput[0]).toBe(NO_NUMBER_INTERPOLATIONS);
+    });
 
-      it('should interpolate values', () => {
-        const tree = (
-          <I18n locale="en" phrases={{ phrase: 'Interpolated: %{message}' }}>
-            <T phrase="phrase" interpolations={{ message: 'Success!' }} />
-          </I18n>
-        );
-        const { getByText } = render(tree);
-        expect(getByText(/^Interpolated:/)).toBeInTheDocument();
-        expect(getByText(/^Interpolated:/).textContent).toBe(
-          'Interpolated: Success!'
-        );
-      });
+    it('should interpolate count', () => {
+      const tree = (
+        <I18n locale="en" phrases={{ phrase: 'Interpolated: %{smart_count}' }}>
+          <T phrase="phrase" count={1} />
+        </I18n>
+      );
+      const { getByText } = render(tree);
+      expect(getByText(/^Interpolated:/)).toBeInTheDocument();
+      expect(getByText(/^Interpolated:/).textContent).toBe('Interpolated: 1');
+    });
 
-      it('should interpolate number as smart count with deprecation warning', () => {
-        const tree = (
-          <I18n
-            locale="en"
-            phrases={{ phrase: 'Interpolated: %{smart_count}' }}
-          >
-            <T phrase="phrase" interpolations={1} />
-          </I18n>
-        );
-        const { getByText } = render(tree);
-        expect(getByText(/^Interpolated:/)).toBeInTheDocument();
-        expect(getByText(/^Interpolated:/).textContent).toBe('Interpolated: 1');
-        expect(consoleOutput).toHaveLength(1);
-        expect(consoleOutput[0]).toBe(NO_NUMBER_INTERPOLATIONS);
-      });
-
-      it('should interpolate count', () => {
-        const tree = (
-          <I18n
-            locale="en"
-            phrases={{ phrase: 'Interpolated: %{smart_count}' }}
-          >
-            <T phrase="phrase" count={1} />
-          </I18n>
-        );
-        const { getByText } = render(tree);
-        expect(getByText(/^Interpolated:/)).toBeInTheDocument();
-        expect(getByText(/^Interpolated:/).textContent).toBe('Interpolated: 1');
-      });
-
-      it('should allow interpolations to override count', () => {
-        const tree = (
-          <I18n
-            locale="en"
-            phrases={{ phrase: 'Interpolated: %{smart_count}' }}
-          >
-            <T phrase="phrase" count={1} interpolations={{ smart_count: 2 }} />
-          </I18n>
-        );
-        const { getByText, queryByText } = render(tree);
-        expect(queryByText(/1$/)).not.toBeInTheDocument();
-        expect(getByText(/^Interpolated:/)).toBeInTheDocument();
-        expect(getByText(/^Interpolated:/).textContent).toBe('Interpolated: 2');
-      });
+    it('should allow interpolations to override count', () => {
+      const tree = (
+        <I18n locale="en" phrases={{ phrase: 'Interpolated: %{smart_count}' }}>
+          <T phrase="phrase" count={1} interpolations={{ smart_count: 2 }} />
+        </I18n>
+      );
+      const { getByText, queryByText } = render(tree);
+      expect(queryByText(/1$/)).not.toBeInTheDocument();
+      expect(getByText(/^Interpolated:/)).toBeInTheDocument();
+      expect(getByText(/^Interpolated:/).textContent).toBe('Interpolated: 2');
     });
   });
 });

--- a/src/__tests__/enhanceT.test.tsx
+++ b/src/__tests__/enhanceT.test.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import Polyglot from 'node-polyglot';
+import enhanceT from '../enhanceT';
+
+describe('Enhance T', () => {
+  const polyglot = new Polyglot({
+    locale: 'en',
+    phrases: {
+      phrase: 'Message',
+      count: 'Count: %{smart_count}',
+      interpolation: 'Interpolated: %{message}',
+      rich_text: '%{component}',
+      rich_text_leading: 'Leading %{component}',
+      rich_text_trailing: '%{component} Trailing',
+    },
+  });
+
+  const enhancedT = enhanceT(polyglot.t.bind(polyglot));
+
+  it('should return a phrase', () => {
+    const callResult = enhancedT('phrase');
+    expect(callResult).toBe('Message');
+  });
+
+  it('should interpolate object values to a phrase', () => {
+    const callResult = enhancedT('interpolation', {
+      message: 'Success!',
+    });
+    expect(callResult).toBe('Interpolated: Success!');
+  });
+
+  it('should interpolate number to a phrase', () => {
+    const callResult = enhancedT('count', 1);
+    expect(callResult).toBe('Count: 1');
+  });
+
+  it('should interpolate smart count to a phrase', () => {
+    const callResult = enhancedT('count', { smart_count: 1 });
+    expect(callResult).toBe('Count: 1');
+  });
+
+  // Because we are testing against an array of ReactNodes here,
+  // we need a full render to allow effective and meaningful comparisons
+  describe('when component interpolations are received', () => {
+    it('should interpolate component to a phrase', () => {
+      const testComponent = <b data-testid="ComponentID">Component</b>;
+      const { getByTestId } = render(
+        enhancedT('rich_text', { component: testComponent })
+      );
+      expect(getByTestId('ComponentID')).toBeInTheDocument();
+      expect(
+        document.querySelector('b[data-testid="ComponentID"]')
+      ).toBeInTheDocument();
+      expect(getByTestId('ComponentID').textContent).toBe('Component');
+    });
+
+    it('should interpolate component with leading string to a phrase', () => {
+      const testComponent = <b data-testid="ComponentID">Component</b>;
+      const { getByText, getByTestId } = render(
+        enhancedT('rich_text_leading', { component: testComponent })
+      );
+      expect(getByText(/^Leading/)).toBeInTheDocument();
+      expect(getByTestId('ComponentID')).toBeInTheDocument();
+      expect(getByText(/^Leading/)).toContainElement(
+        getByTestId('ComponentID')
+      );
+      expect(getByText(/^Leading/).textContent).toBe('Leading Component');
+    });
+
+    it('should interpolate component with trailing string to a phrase', () => {
+      const testComponent = <b data-testid="ComponentID">Component</b>;
+      const { getByText, getByTestId } = render(
+        enhancedT('rich_text_trailing', { component: testComponent })
+      );
+      expect(getByText(/Trailing$/)).toBeInTheDocument();
+      expect(getByTestId('ComponentID')).toBeInTheDocument();
+      expect(getByText(/Trailing$/)).toContainElement(
+        getByTestId('ComponentID')
+      );
+      expect(getByText(/Trailing$/).textContent).toBe('Component Trailing');
+    });
+  });
+
+  describe('when the called phrase is not found', () => {
+    const originalConsoleError = console.error;
+
+    let consoleOutput: string[] = [];
+    beforeEach(() => {
+      console.error = (...args: string[]): void => {
+        args.forEach(arg => consoleOutput.push(arg));
+      };
+    });
+
+    afterEach(() => {
+      consoleOutput = [];
+      console.error = originalConsoleError;
+    });
+
+    it('should return the key and emit a warning', () => {
+      const callResult = enhancedT('unavailable');
+      expect(callResult).toBe('unavailable');
+      expect(consoleOutput).toHaveLength(1);
+      expect(consoleOutput[0]).toBe(
+        'Warning: Missing translation for key: "unavailable"'
+      );
+    });
+
+    it('should not interpolate without a fallback', () => {
+      const callResult = enhancedT('unavailable', {
+        message: 'Failed!',
+      });
+      expect(callResult).not.toContain('Failed!');
+      expect(callResult).toBe('unavailable');
+    });
+
+    it('should interpolate to the fallback when available', () => {
+      const callResult = enhancedT('unavailable', {
+        _: 'Fallback: %{message}',
+        message: 'Success!',
+      });
+      expect(callResult).not.toContain('unavailable');
+      expect(callResult).toBe('Fallback: Success!');
+    });
+  });
+});

--- a/src/__tests__/i18nContext.test.tsx
+++ b/src/__tests__/i18nContext.test.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { spy } from 'sinon';
+import { ValueTester } from '../../test';
+import { NO_POLYGLOT_CONTEXT } from '../constants';
+import I18nContext from '../i18nContext';
+
+describe('I18n Context', () => {
+  const originalConsoleError = console.error;
+
+  let consoleOutput: string[] = [];
+  beforeEach(() => {
+    console.error = (...args: string[]): void => {
+      args.forEach(arg => consoleOutput.push(arg));
+    };
+  });
+
+  afterEach(() => {
+    consoleOutput = [];
+    console.error = originalConsoleError;
+  });
+
+  it('should only pass locale and t to children via context', () => {
+    const readValue = spy();
+    const tree = (
+      <I18nContext.Provider value={{ locale: undefined, t: () => undefined }}>
+        <I18nContext.Consumer>
+          {values => <ValueTester callback={readValue} value={values} />}
+        </I18nContext.Consumer>
+      </I18nContext.Provider>
+    );
+    render(tree);
+    const calledValue = readValue.getCall(0).args[0];
+    expect(typeof calledValue).toBe('object');
+
+    const valueKeys = Object.keys(calledValue);
+    expect(valueKeys).toHaveLength(2);
+    expect(valueKeys).toStrictEqual(['locale', 't']);
+  });
+
+  it('should provide undefined locale without context', () => {
+    const readValue = spy();
+    const tree = (
+      <I18nContext.Consumer>
+        {({ locale }) => <ValueTester callback={readValue} value={locale} />}
+      </I18nContext.Consumer>
+    );
+    render(tree);
+    const calledValue = readValue.getCall(0).args[0];
+    expect(calledValue).toBe(undefined);
+  });
+
+  it('should provide a fallback t function without context', () => {
+    const readValue = spy();
+    const tree = (
+      <I18nContext.Consumer>
+        {({ t }) => <ValueTester callback={readValue} value={t} />}
+      </I18nContext.Consumer>
+    );
+    render(tree);
+    const calledValue = readValue.getCall(0).args[0];
+    expect(typeof calledValue).toBe('function');
+    expect(calledValue.toString()).toContain('function warnWithoutContext');
+    expect(calledValue('phrase')).toBe('phrase');
+    expect(consoleOutput).toHaveLength(1);
+    expect(consoleOutput[0]).toBe(NO_POLYGLOT_CONTEXT);
+  });
+
+  describe('In Production', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+
+    beforeAll(() => {
+      process.env.NODE_ENV = 'production';
+    });
+
+    afterAll(() => {
+      process.env.NODE_ENV = originalNodeEnv;
+    });
+
+    it('should silence fallback t function warnings', () => {
+      const readValue = spy();
+      const tree = (
+        <I18nContext.Consumer>
+          {({ t }) => <ValueTester callback={readValue} value={t} />}
+        </I18nContext.Consumer>
+      );
+      render(tree);
+      readValue.getCall(0).args[0]('phrase');
+      expect(consoleOutput).toHaveLength(0);
+    });
+  });
+});

--- a/src/__tests__/useLocale.test.tsx
+++ b/src/__tests__/useLocale.test.tsx
@@ -3,23 +3,19 @@ import { renderHook } from '@testing-library/react-hooks';
 import { I18n, useLocale } from '..';
 
 describe('Use Locale', () => {
-  describe('when context is not provided', () => {
-    it('should return undefined', () => {
-      const { result } = renderHook(() => useLocale());
-      expect(result.current).toBe(undefined);
-    });
+  it('should return undefined without context', () => {
+    const { result } = renderHook(() => useLocale());
+    expect(result.current).toBe(undefined);
   });
 
-  describe('when context is provided', () => {
-    it('should return I18n locale string', () => {
-      const wrapper: React.FC = ({ children }) => (
-        <I18n locale="en" phrases={{}}>
-          {children}
-        </I18n>
-      );
-      const { result } = renderHook(() => useLocale(), { wrapper });
-      expect(typeof result.current).toBe('string');
-      expect(result.current).toBe('en');
-    });
+  it('should return the locale string with context', () => {
+    const wrapper: React.FC = ({ children }) => (
+      <I18n locale="en" phrases={{}}>
+        {children}
+      </I18n>
+    );
+    const { result } = renderHook(() => useLocale(), { wrapper });
+    expect(typeof result.current).toBe('string');
+    expect(result.current).toBe('en');
   });
 });

--- a/src/__tests__/useT.test.tsx
+++ b/src/__tests__/useT.test.tsx
@@ -1,110 +1,22 @@
 import * as React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { I18n, useT } from '..';
-import { NO_POLYGLOT_CONTEXT } from '../constants';
 
 describe('Use T', () => {
-  const originalConsoleError = console.error;
-
-  let consoleOutput: string[] = [];
-  beforeEach(() => {
-    console.error = (...args: string[]): void => {
-      args.forEach(arg => consoleOutput.push(arg));
-    };
-  });
-
-  afterEach(() => {
-    consoleOutput = [];
-    console.error = originalConsoleError;
-  });
-
-  it('should return a function', () => {
+  it('should return the fallback function without context', () => {
     const { result } = renderHook(() => useT());
     expect(typeof result.current).toBe('function');
+    expect(result.current.toString()).toContain('function warnWithoutContext');
   });
 
-  describe('when context is not provided', () => {
-    it('should return key on call and emit a warning', () => {
-      const { result } = renderHook(() => useT());
-      const callResult = result.current('phrase');
-      expect(callResult).toBe('phrase');
-      expect(consoleOutput).toHaveLength(1);
-      expect(consoleOutput[0]).toBe(NO_POLYGLOT_CONTEXT);
-    });
-  });
-
-  describe('when context is provided', () => {
-    describe('when the called phrase is not found', () => {
-      it('should return the key and emit a warning', () => {
-        const wrapper: React.FC = ({ children }) => (
-          <I18n locale="en" phrases={{ phrase: 'Message' }}>
-            {children}
-          </I18n>
-        );
-        const { result } = renderHook(() => useT(), { wrapper });
-        const callResult = result.current('unavailable');
-        expect(callResult).toBe('unavailable');
-        expect(consoleOutput).toHaveLength(1);
-        expect(consoleOutput[0]).toBe(
-          'Warning: Missing translation for key: "unavailable"'
-        );
-      });
-
-      it('should not interpolate without a fallback', () => {
-        const wrapper: React.FC = ({ children }) => (
-          <I18n locale="en" phrases={{ phrase: 'Message' }}>
-            {children}
-          </I18n>
-        );
-        const { result } = renderHook(() => useT(), { wrapper });
-        const callResult = result.current('unavailable', {
-          message: 'Failed!',
-        });
-        expect(callResult).not.toContain('Failed!');
-        expect(callResult).toBe('unavailable');
-      });
-
-      it('should interpolate to the fallback', () => {
-        const wrapper: React.FC = ({ children }) => (
-          <I18n locale="en" phrases={{ phrase: 'Message' }}>
-            {children}
-          </I18n>
-        );
-        const { result } = renderHook(() => useT(), { wrapper });
-        const callResult = result.current('unavailable', {
-          _: 'Fallback: %{message}',
-          message: 'Success!',
-        });
-        expect(callResult).not.toContain('unavailable');
-        expect(callResult).toBe('Fallback: Success!');
-      });
-    });
-
-    describe('when the called phrase is found', () => {
-      it('should return the phrase without warning', () => {
-        const wrapper: React.FC = ({ children }) => (
-          <I18n locale="en" phrases={{ phrase: 'Message' }}>
-            {children}
-          </I18n>
-        );
-        const { result } = renderHook(() => useT(), { wrapper });
-        const callResult = result.current('phrase');
-        expect(callResult).toBe('Message');
-        expect(consoleOutput).toHaveLength(0);
-      });
-
-      it('should interpolate to the phrase', () => {
-        const wrapper: React.FC = ({ children }) => (
-          <I18n locale="en" phrases={{ phrase: 'Interpolated: %{message}' }}>
-            {children}
-          </I18n>
-        );
-        const { result } = renderHook(() => useT(), { wrapper });
-        const callResult = result.current('phrase', {
-          message: 'Success!',
-        });
-        expect(callResult).toBe('Interpolated: Success!');
-      });
-    });
+  it('should return the t function with context', () => {
+    const wrapper: React.FC = ({ children }) => (
+      <I18n locale="en" phrases={{}}>
+        {children}
+      </I18n>
+    );
+    const { result } = renderHook(() => useT(), { wrapper });
+    expect(typeof result.current).toBe('function');
+    expect(result.current.toString()).toContain('function t');
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,9 @@
 import Polyglot from 'node-polyglot';
+import enhanceT from './enhanceT';
 
 export type PolyglotT = typeof Polyglot.prototype.t;
+
+export type tFunction = ReturnType<typeof enhanceT>;
 
 // TODO: Remove after deprecation of number from interpolations in v0.3.0
 export const NO_NUMBER_INTERPOLATIONS = [

--- a/src/enhanceT.ts
+++ b/src/enhanceT.ts
@@ -9,12 +9,12 @@ const enhanceT = (originalT: PolyglotT) => {
   function t(
     key: Parameters<PolyglotT>[0],
     interpolations?: Parameters<PolyglotT>[1]
-  ): ReactNode;
+  ): ReactElement;
   // We use a named function here to aid debugging
   // ReactNode includes all React render-ables, including arrays
-  function t(...[key, interpolations]: Parameters<PolyglotT>): ReactNode {
+  function t(...[key, interpolations]: Parameters<PolyglotT>): ReactElement {
     if (interpolations === undefined || typeof interpolations === 'number') {
-      return originalT(key, interpolations);
+      return (originalT(key, interpolations) as ReactNode) as ReactElement;
     } else {
       // ReactElement used because cloneElement requires a proper ReactElement
       const elementCache: ReactElement[] = [];
@@ -29,7 +29,7 @@ const enhanceT = (originalT: PolyglotT) => {
       const tString = originalT(key, interpolations);
       // We can safely return if no element interpolation is needed
       if (!elementCache.length) {
-        return tString;
+        return (tString as ReactNode) as ReactElement;
       }
 
       // Split the string into chunks of strings and interpolation indices
@@ -57,7 +57,7 @@ const enhanceT = (originalT: PolyglotT) => {
         }
       }
 
-      return renderItems;
+      return (renderItems as ReactNode) as ReactElement;
     }
   }
 

--- a/src/enhanceT.ts
+++ b/src/enhanceT.ts
@@ -5,7 +5,7 @@ import { PolyglotT } from './constants';
 const IDENTIFIER = /<(\d+)\/>/;
 
 const enhanceT = (originalT: PolyglotT) => {
-  // An overload is included to aid with code auto-completion
+  // An overload is included to aid code auto-completion
   function t(
     key: Parameters<PolyglotT>[0],
     interpolations?: Parameters<PolyglotT>[1]

--- a/src/enhanceT.ts
+++ b/src/enhanceT.ts
@@ -4,7 +4,12 @@ import { PolyglotT } from './constants';
 // A pseudo-JSX string interpolation identifier
 const IDENTIFIER = /<(\d+)\/>/;
 
-const enhanceT = (originalT: PolyglotT) =>
+const enhanceT = (originalT: PolyglotT) => {
+  // An overload is included to aid with code auto-completion
+  function t(
+    key: Parameters<PolyglotT>[0],
+    interpolations?: Parameters<PolyglotT>[1]
+  ): ReactNode;
   // We use a named function here to aid debugging
   // ReactNode includes all React render-ables, including arrays
   function t(...[key, interpolations]: Parameters<PolyglotT>): ReactNode {
@@ -54,6 +59,9 @@ const enhanceT = (originalT: PolyglotT) =>
 
       return renderItems;
     }
-  };
+  }
+
+  return t;
+};
 
 export default enhanceT;

--- a/src/enhanceT.ts
+++ b/src/enhanceT.ts
@@ -1,0 +1,59 @@
+import { cloneElement, isValidElement, ReactElement, ReactNode } from 'react';
+import { PolyglotT } from './constants';
+
+// A pseudo-JSX string interpolation identifier
+const IDENTIFIER = /<(\d+)\/>/;
+
+const enhanceT = (originalT: PolyglotT) =>
+  // We use a named function here to aid debugging
+  // ReactNode includes all React render-ables, including arrays
+  function t(...[key, interpolations]: Parameters<PolyglotT>): ReactNode {
+    if (interpolations === undefined || typeof interpolations === 'number') {
+      return originalT(key, interpolations);
+    } else {
+      // ReactElement used because cloneElement requires a proper ReactElement
+      const elementCache: ReactElement[] = [];
+      Object.keys(interpolations).forEach(key => {
+        // Store all JSX elements into a array cache for processing later
+        if (isValidElement(interpolations[key])) {
+          elementCache.push(interpolations[key]);
+          interpolations[key] = `<${elementCache.length - 1}/>`;
+        }
+      });
+
+      const tString = originalT(key, interpolations);
+      // We can safely return if no element interpolation is needed
+      if (!elementCache.length) {
+        return tString;
+      }
+
+      // Split the string into chunks of strings and interpolation indices
+      const tChunks = tString.split(IDENTIFIER);
+      // Move the leading string part into the render array and pop it
+      const renderItems: Array<ReactNode> = tChunks.splice(0, 1);
+      for (let i = 0; i < Math.ceil(tChunks.length); i += 1) {
+        const [index, trailingString] = tChunks.splice(0, 2);
+        const currentIndex = parseInt(index, 10);
+        const currentElement = elementCache[currentIndex];
+
+        // Interpolate the element
+        renderItems.push(
+          cloneElement(
+            currentElement,
+            // A unique key is needed when rendering an array
+            { key: currentIndex },
+            currentElement.props.children
+          )
+        );
+
+        // Interpolate any trailing string
+        if (trailingString) {
+          renderItems.push(trailingString);
+        }
+      }
+
+      return renderItems;
+    }
+  };
+
+export default enhanceT;

--- a/src/i18nContext.ts
+++ b/src/i18nContext.ts
@@ -1,4 +1,4 @@
-import { createContext } from 'react';
+import { createContext, ReactElement, ReactNode } from 'react';
 import { NO_POLYGLOT_CONTEXT, tFunction } from './constants';
 
 function warnWithoutContext(
@@ -7,7 +7,7 @@ function warnWithoutContext(
   if (process.env.NODE_ENV !== 'production') {
     console.error(NO_POLYGLOT_CONTEXT);
   }
-  return key;
+  return (key as ReactNode) as ReactElement;
 }
 
 export interface I18nContextProps {

--- a/src/i18nContext.ts
+++ b/src/i18nContext.ts
@@ -1,7 +1,9 @@
 import { createContext } from 'react';
-import { NO_POLYGLOT_CONTEXT, PolyglotT } from './constants';
+import { NO_POLYGLOT_CONTEXT, tFunction } from './constants';
 
-function warnWithoutContext(...[key]: Parameters<PolyglotT>): string {
+function warnWithoutContext(
+  ...[key]: Parameters<tFunction>
+): ReturnType<tFunction> {
   if (process.env.NODE_ENV !== 'production') {
     console.error(NO_POLYGLOT_CONTEXT);
   }
@@ -10,7 +12,7 @@ function warnWithoutContext(...[key]: Parameters<PolyglotT>): string {
 
 export interface I18nContextProps {
   locale: string | undefined;
-  t: PolyglotT;
+  t: tFunction;
 }
 
 const I18nContext = createContext<I18nContextProps>({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { PolyglotT } from './constants';
+export { tFunction } from './constants';
 export { default as I18n, I18nProps } from './I18n';
 export { I18nContextProps } from './i18nContext';
 export { default as T, TProps } from './T';

--- a/src/useT.ts
+++ b/src/useT.ts
@@ -1,8 +1,8 @@
 import { useContext } from 'react';
-import { PolyglotT } from './constants';
+import { tFunction } from './constants';
 import I18nContext from './i18nContext';
 
-const useT = (): PolyglotT => {
+const useT = (): tFunction => {
   const { t } = useContext(I18nContext);
   return t;
 };


### PR DESCRIPTION
This PR adds an enhancer to the polyglot t function as the first step to allow rich text interpolations by passing in components. General simplification of tests have also been done because tests related to `t` can be directly done in isolation with the new function generated with `enhanceT`.

Partially handles #4 : Other aspects of rich text support may still be lacking