### PR TITLE
feat: add support for custom plural rules

### DIFF
--- a/src/I18n.tsx
+++ b/src/I18n.tsx
@@ -21,8 +21,9 @@ const I18n: React.FC<I18nProps> = ({
   locale,
   phrases,
   allowMissing,
-  onMissingKey,
   interpolation,
+  onMissingKey,
+  pluralRules,
 }) => {
   const polyglot = React.useMemo<Polyglot>(
     // Create a new instance on every change
@@ -32,10 +33,11 @@ const I18n: React.FC<I18nProps> = ({
         locale,
         phrases,
         allowMissing,
-        onMissingKey,
         interpolation,
+        onMissingKey,
+        pluralRules,
       }),
-    [locale, phrases, allowMissing, onMissingKey, interpolation]
+    [locale, phrases, allowMissing, interpolation, onMissingKey, pluralRules]
   );
 
   const polyglotContext = React.useMemo(

--- a/src/__tests__/i18nContext.test.tsx
+++ b/src/__tests__/i18nContext.test.tsx
@@ -23,7 +23,12 @@ describe('I18n Context', () => {
   it('should only pass locale and t to children via context', () => {
     const readValue = spy();
     const tree = (
-      <I18nContext.Provider value={{ locale: undefined, t: () => undefined }}>
+      <I18nContext.Provider
+        value={{
+          locale: undefined,
+          t: () => (undefined as React.ReactNode) as React.ReactElement,
+        }}
+      >
         <I18nContext.Consumer>
           {values => <ValueTester callback={readValue} value={values} />}
         </I18nContext.Consumer>

--- a/src/vendors.d.ts
+++ b/src/vendors.d.ts
@@ -31,6 +31,6 @@ declare module 'node-polyglot' {
       locale?: string
     ) => string;
     interpolation?: InterpolationParams;
-    pluralRules: PluralRules;
+    pluralRules?: PluralRules;
   }
 }

--- a/src/vendors.d.ts
+++ b/src/vendors.d.ts
@@ -1,0 +1,36 @@
+// Override Type definitions for node-polyglot v2.4.0
+// TODO: Remove after types are merged to DefinitelyTyped
+import { InterpolationOptions } from 'node-polyglot';
+
+declare module 'node-polyglot' {
+  interface InterpolationParams {
+    suffix?: string;
+    prefix?: string;
+  }
+
+  interface PluralType {
+    [pluralType: string]: (count: number) => void;
+  }
+
+  interface PluralTypeToLanguages {
+    [pluralType: string]: string[];
+  }
+
+  interface PluralRules {
+    pluralTypes?: PluralType;
+    pluralTypeToLanguages?: PluralTypeToLanguages;
+  }
+
+  interface PolyglotOptions {
+    phrases?: any;
+    locale?: string;
+    allowMissing?: boolean;
+    onMissingKey?: (
+      key: string,
+      options?: InterpolationOptions,
+      locale?: string
+    ) => string;
+    interpolation?: InterpolationParams;
+    pluralRules: PluralRules;
+  }
+}


### PR DESCRIPTION
This PR adds support to custom plural rules added in `node-polyglot` v2.4.0.
Resolves #37 