### PR TITLE
feat!: remove number interpolations for T component

### DIFF
--- a/src/T.tsx
+++ b/src/T.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { NO_NUMBER_INTERPOLATIONS } from './constants';
 import useT from './useT';
 import type { InterpolationOptions } from 'node-polyglot';
 
@@ -12,7 +11,7 @@ export interface TProps {
   /** A fallback phrase to render when the provided key does not resolve. */
   fallback?: string;
   /** A key-value map of components or strings to be interpolated. */
-  interpolations?: number | InterpolationOptions;
+  interpolations?: InterpolationOptions;
   /** The key of the phrase to render. */
   phrase: string;
 }
@@ -23,24 +22,12 @@ export interface TProps {
 const T: React.FC<TProps> = ({ count, fallback, interpolations, phrase }) => {
   const t = useT();
 
-  let cleanInterpolations;
-  if (typeof interpolations !== 'number') {
-    cleanInterpolations = interpolations;
-  } else {
-    // TODO: Deprecate number from interpolations in v0.4.0
-    // Handles number interpolation
-    cleanInterpolations = { smart_count: interpolations };
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(NO_NUMBER_INTERPOLATIONS);
-    }
-  }
-
   const tOptions = {
     // Check for truthy prop values before assigning
     // This is done to prevent altering the specific options
     ...(fallback && { _: fallback }),
     ...(count && { smart_count: count }),
-    ...cleanInterpolations,
+    ...interpolations,
   };
 
   // HACK: A workaround for the current limitations of TSX with FC

--- a/src/__tests__/T.test.tsx
+++ b/src/__tests__/T.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
-import { NO_NUMBER_INTERPOLATIONS } from '../constants';
 import { I18n, T } from '..';
 
 describe('T Component', () => {
@@ -89,17 +88,20 @@ describe('T Component', () => {
       );
     });
 
-    it('should interpolate number as smart count with deprecation warning', () => {
+    it('should not interpolate number as smart count', () => {
       const tree = (
         <I18n locale="en" phrases={{ phrase: 'Interpolated: %{smart_count}' }}>
+          {/*
+          TODO: Update to @ts-expect-error
+          // @ts-ignore */}
           <T phrase="phrase" interpolations={1} />
         </I18n>
       );
       const { getByText } = render(tree);
       expect(getByText(/^Interpolated:/)).toBeInTheDocument();
-      expect(getByText(/^Interpolated:/).textContent).toBe('Interpolated: 1');
-      expect(consoleOutput).toHaveLength(1);
-      expect(consoleOutput[0]).toBe(NO_NUMBER_INTERPOLATIONS);
+      expect(getByText(/^Interpolated:/).textContent).toBe(
+        'Interpolated: %{smart_count}'
+      );
     });
 
     it('should interpolate count', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,3 @@
-// TODO: Remove after deprecation of number from interpolations in v0.4.0
-export const NO_NUMBER_INTERPOLATIONS = [
-  'Warning:',
-  'Use of the interpolations prop as a shorthand for smart_count have been deprecated in favor of the count prop and will be removed in the next major version.',
-  'Please update your app to use that instead.',
-].join(' ');
-
 export const NO_POLYGLOT_CONTEXT = [
   'Warning:',
   't is called without Polyglot context.',


### PR DESCRIPTION
This PR removes the deprecated `number`-type for the `interpolations` prop in the T component.